### PR TITLE
Fix for older Emacs

### DIFF
--- a/zone-sl.el
+++ b/zone-sl.el
@@ -406,8 +406,8 @@
     (zone)))
 
 (defvar eshell-command-aliases-list)
-(with-eval-after-load "em-alias"
-  (add-to-list 'eshell-command-aliases-list '("sl" "zone-sl")))
+(eval-after-load "em-alias"
+  '(add-to-list 'eshell-command-aliases-list '("sl" "zone-sl")))
 
 (provide 'zone-sl)
 ;;; zone-sl.el ends here


### PR DESCRIPTION
with-eval-after-load was introduced at Emacs 24.4.
